### PR TITLE
fix: use npm-style scoped package name for mpak compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "0.3",
-  "name": "tools.ref/ref-tools-mcp",
+  "name": "@ref-tools/ref-tools-mcp",
   "version": "3.0.3",
   "description": "Token-efficient documentation search for AI coding agents",
   "author": {


### PR DESCRIPTION
## Summary
- Changes manifest name from `tools.ref/ref-tools-mcp` to `@ref-tools/ref-tools-mcp`
- Fixes mpak compatibility issue where package names must start with `@` (npm-style scoped packages)

## Background
The mpak CLI validates that package names are scoped in npm format (e.g., `@username/package-name`). The previous format `tools.ref/ref-tools-mcp` caused mpak commands to fail with:

```
Error: Package name must be scoped (e.g., @username/package-name)
```

## Test plan
- [x] Verified `mcpb pack` succeeds with new name
- [x] Verified server starts correctly via stdio transport