### PR TITLE
Task 4: Create cli_users with grant-credits subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .awolf
 .smithery
 .mcpregistry*
+firebase-debug.log
+firestore-debug.log

--- a/command/cli_common.ts
+++ b/command/cli_common.ts
@@ -1,0 +1,38 @@
+import { config } from 'dotenv'
+import { initializeApp, cert, type ServiceAccount } from 'firebase-admin/app'
+import { getFirestore, type Firestore } from 'firebase-admin/firestore'
+
+export type CliBootstrapResult = {
+  db: Firestore
+  emulator: boolean
+}
+
+/**
+ * Shared bootstrap for CLI tools: loads .env, optionally configures
+ * the Firestore emulator, initialises Firebase Admin, and returns the db handle.
+ */
+export function bootstrap(opts: { emulator?: boolean }): CliBootstrapResult {
+  config()
+
+  const useEmulator = opts.emulator ?? false
+
+  if (useEmulator) {
+    process.env['FIRESTORE_EMULATOR_HOST'] = process.env['FIRESTORE_EMULATOR_HOST'] || 'localhost:8080'
+    console.log(`[cli] Using Firestore emulator at ${process.env['FIRESTORE_EMULATOR_HOST']}`)
+
+    initializeApp({ projectId: process.env['GCLOUD_PROJECT'] || 'demo-project' })
+  } else {
+    const serviceAccountPath = process.env['GOOGLE_APPLICATION_CREDENTIALS']
+    if (serviceAccountPath) {
+      // Dynamic import would be async; require is fine for CLI bootstrap
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const sa = require(serviceAccountPath) as ServiceAccount
+      initializeApp({ credential: cert(sa) })
+    } else {
+      initializeApp()
+    }
+  }
+
+  const db = getFirestore()
+  return { db, emulator: useEmulator }
+}

--- a/command/cli_users.ts
+++ b/command/cli_users.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * CLI for user-scoped admin operations (credit grants, user info, etc.).
+ *
+ * Usage:
+ *   npx tsx command/cli_users.ts [--emulator] <command> [options]
+ *
+ * Commands:
+ *   grant-credits <userId>  Grant credits to a user
+ *   info <userId>           Show user info (email, tier, credits, teams)
+ */
+
+import { Command, InvalidArgumentError } from 'commander'
+import { bootstrap } from './cli_common.js'
+import {
+  addCredits,
+  getUserCreditInfo,
+  findUserByEmail,
+} from '../functions/src/services/credits.js'
+
+const program = new Command()
+
+program
+  .name('cli_users')
+  .description('User-scoped admin CLI for Ref')
+  .version('1.0.0')
+  .option('--emulator', 'Connect to the Firestore emulator instead of production')
+
+// ── grant-credits ──────────────────────────────────────────────────────────
+
+program
+  .command('grant-credits <userId>')
+  .description('Grant credits to a user')
+  .requiredOption('--credits <n>', 'Number of credits to grant (positive integer)', (v) => {
+    const n = parseInt(v, 10)
+    if (isNaN(n) || n <= 0 || !Number.isInteger(n)) {
+      throw new InvalidArgumentError('--credits must be a positive integer')
+    }
+    return n
+  })
+  .requiredOption('--reason <string>', 'Reason for the credit grant')
+  .action(async (userId: string, opts: { credits: number; reason: string }) => {
+    const { db, emulator } = bootstrap({ emulator: program.opts()['emulator'] as boolean | undefined })
+    const env = emulator ? '(emulator)' : '(production)'
+
+    console.log(`\n[grant-credits] ${env}`)
+    console.log(`  Target user: ${userId}`)
+    console.log(`  Firestore path: users/${userId}`)
+
+    // Validate user exists and print identifying info
+    let info
+    try {
+      info = await getUserCreditInfo(db, userId)
+    } catch {
+      console.error(`\n✗ User "${userId}" does not exist in Firestore. No writes performed.`)
+      process.exit(1)
+    }
+
+    console.log(`  Email: ${info.email}`)
+    if (info.teamMemberships.length > 0) {
+      console.log(`  Teams: ${info.teamMemberships.map((t) => `${t.teamName} (${t.role})`).join(', ')}`)
+    }
+    console.log(`  Current balance: ${info.creditBalance}`)
+    console.log(`  Granting: +${opts.credits} credits`)
+    console.log(`  Reason: "${opts.reason}"`)
+    console.log()
+
+    const { newBalance } = await addCredits(db, userId, opts.credits, opts.reason)
+
+    console.log(`✓ Granted ${opts.credits} credits to ${info.email || userId}`)
+    console.log(`  New balance: ${newBalance}`)
+    console.log(`  Transaction log: users/${userId}/creditTransactions/<new>`)
+    console.log()
+
+    process.exit(0)
+  })
+
+// ── info ───────────────────────────────────────────────────────────────────
+
+program
+  .command('info <userId>')
+  .description('Print user info: email, tier, credits, team memberships, monthly allowance')
+  .action(async (userId: string) => {
+    const { db, emulator } = bootstrap({ emulator: program.opts()['emulator'] as boolean | undefined })
+    const env = emulator ? '(emulator)' : '(production)'
+
+    // If the argument looks like an email, resolve it to a userId first
+    let resolvedUserId = userId
+    if (userId.includes('@')) {
+      console.log(`\n[info] ${env} — looking up user by email: ${userId}`)
+      const found = await findUserByEmail(db, userId)
+      if (!found) {
+        console.error(`\n✗ No user found with email "${userId}"`)
+        process.exit(1)
+      }
+      resolvedUserId = found
+      console.log(`  Resolved to userId: ${resolvedUserId}`)
+    }
+
+    let info
+    try {
+      info = await getUserCreditInfo(db, resolvedUserId)
+    } catch {
+      console.error(`\n✗ User "${resolvedUserId}" does not exist in Firestore.`)
+      process.exit(1)
+    }
+
+    console.log(`\n[info] ${env}`)
+    console.log(`  Firestore path: users/${info.userId}`)
+    console.log(`  Email:           ${info.email || '(not set)'}`)
+    console.log(`  Tier:            ${info.tier}`)
+    console.log(`  Credit balance:  ${info.creditBalance}`)
+    console.log(`  Monthly allow.:  ${info.monthlyAllowance ?? 'none'}`)
+
+    if (info.teamMemberships.length > 0) {
+      console.log(`  Teams:`)
+      for (const t of info.teamMemberships) {
+        console.log(`    - ${t.teamName} (${t.role}) [teams/${t.teamId}]`)
+      }
+    } else {
+      console.log(`  Teams:           (none)`)
+    }
+    console.log()
+
+    process.exit(0)
+  })
+
+program.parse()

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,8 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8080,
+      "host": "localhost"
+    }
+  }
+}

--- a/functions/src/services/credits.ts
+++ b/functions/src/services/credits.ts
@@ -1,0 +1,96 @@
+import type { Firestore } from 'firebase-admin/firestore'
+
+export type CreditInfo = {
+  userId: string
+  email: string
+  tier: string
+  creditBalance: number
+  monthlyAllowance: number | null
+  teamMemberships: Array<{ teamId: string; teamName: string; role: string }>
+}
+
+/**
+ * Add credits to a user's account. Performs an atomic increment on the
+ * user's credit balance and logs the transaction.
+ */
+export async function addCredits(
+  db: Firestore,
+  userId: string,
+  amount: number,
+  reason: string,
+): Promise<{ newBalance: number }> {
+  const userRef = db.collection('users').doc(userId)
+
+  const newBalance = await db.runTransaction(async (tx) => {
+    const snap = await tx.get(userRef)
+    if (!snap.exists) {
+      throw new Error(`User ${userId} does not exist`)
+    }
+
+    const data = snap.data()!
+    const currentBalance: number = (data['creditBalance'] as number) ?? 0
+    const updated = currentBalance + amount
+
+    tx.update(userRef, { creditBalance: updated })
+
+    const txRef = db.collection('users').doc(userId).collection('creditTransactions').doc()
+    tx.set(txRef, {
+      amount,
+      reason,
+      balanceBefore: currentBalance,
+      balanceAfter: updated,
+      createdAt: new Date().toISOString(),
+    })
+
+    return updated
+  })
+
+  return { newBalance }
+}
+
+/**
+ * Retrieve credit and profile info for a user.
+ */
+export async function getUserCreditInfo(db: Firestore, userId: string): Promise<CreditInfo> {
+  const userSnap = await db.collection('users').doc(userId).get()
+  if (!userSnap.exists) {
+    throw new Error(`User ${userId} does not exist`)
+  }
+
+  const data = userSnap.data()!
+  const email: string = (data['email'] as string) ?? ''
+  const tier: string = (data['tier'] as string) ?? 'free'
+  const creditBalance: number = (data['creditBalance'] as number) ?? 0
+  const monthlyAllowance: number | null = (data['monthlyAllowance'] as number) ?? null
+
+  const membershipsSnap = await db
+    .collection('teamMembers')
+    .where('userId', '==', userId)
+    .get()
+
+  const teamMemberships: CreditInfo['teamMemberships'] = []
+  for (const doc of membershipsSnap.docs) {
+    const m = doc.data()
+    const teamSnap = await db.collection('teams').doc(m['teamId'] as string).get()
+    const teamData = teamSnap.data()
+    teamMemberships.push({
+      teamId: m['teamId'] as string,
+      teamName: (teamData?.['name'] as string) ?? '(unknown)',
+      role: (m['role'] as string) ?? 'member',
+    })
+  }
+
+  return { userId, email, tier, creditBalance, monthlyAllowance, teamMemberships }
+}
+
+/**
+ * Look up a user by email. Returns the userId or null if not found.
+ */
+export async function findUserByEmail(
+  db: Firestore,
+  email: string,
+): Promise<string | null> {
+  const snap = await db.collection('users').where('email', '==', email).limit(1).get()
+  if (snap.empty) return null
+  return snap.docs[0]!.id
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@modelcontextprotocol/inspector": "^0.16.1",
         "@modelcontextprotocol/sdk": "^1.0.3",
         "axios": "^1.8.4",
+        "commander": "^14.0.3",
+        "dotenv": "^17.4.2",
         "firebase-admin": "^13.8.0"
       },
       "bin": {
@@ -1542,6 +1544,15 @@
       },
       "bin": {
         "mcp-inspector-cli": "build/cli.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@modelcontextprotocol/inspector-client": {
@@ -3498,12 +3509,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -3743,6 +3754,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start:http": "TRANSPORT=http node dist/index.cjs",
     "dev": "concurrently \"npm run watch\" \"npm run inspect\"",
     "check": "tsc --noEmit",
+    "cli:users": "npx tsx command/cli_users.ts",
     "pre-commit": "npm run check",
     "prepublishOnly": "npm run build"
   },
@@ -26,6 +27,8 @@
     "@modelcontextprotocol/inspector": "^0.16.1",
     "@modelcontextprotocol/sdk": "^1.0.3",
     "axios": "^1.8.4",
+    "commander": "^14.0.3",
+    "dotenv": "^17.4.2",
     "firebase-admin": "^13.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a user-scoped admin CLI (`command/cli_users.ts`) for credit management and user info lookups, backed by a new Firestore credit service.

## New Files

### `functions/src/services/credits.ts`
Credit service with three functions:
- **`addCredits(db, userId, amount, reason)`** — atomically increments credit balance and logs a transaction document
- **`getUserCreditInfo(db, userId)`** — returns email, tier, credit balance, monthly allowance, and team memberships
- **`findUserByEmail(db, email)`** — resolves an email to a userId

### `command/cli_common.ts`
Shared CLI bootstrap extracted for reuse across CLIs:
- Loads `.env` via dotenv
- `--emulator` flag wires up `FIRESTORE_EMULATOR_HOST`
- Initialises Firebase Admin (supports service account file or default credentials)

### `command/cli_users.ts`
User-scoped admin CLI with two subcommands:

**`grant-credits <userId> --credits <n> --reason <string>`**
- Validates userId exists in Firestore before making any writes
- Prints user email and team memberships for confirmation
- Calls `addCredits` and prints the new balance
- `--credits` must be a positive integer

**`info <userId>`**
- Prints: email, tier, credit balance, monthly allowance, team memberships
- Accepts email as the argument (auto-resolves to userId)

### `firebase.json`
Minimal emulator config for local development.

## package.json Changes
- Added `npm run cli:users` script
- Added dependencies: `firebase-admin`, `commander`, `dotenv`

## Testing

All commands tested against the Firestore emulator:

| Test | Result |
|------|--------|
| `info` on non-existent user | ✅ Clean error, exit code 1 |
| `info` on existing user | ✅ Shows email, tier, balance, teams |
| `grant-credits` on non-existent user | ✅ Clean error, no writes |
| `grant-credits` on existing user | ✅ Balance updated, transaction logged |
| `info` after grant (verify balance) | ✅ Balance reflects grant |
| `--credits 0`, `--credits -5`, `--credits abc` | ✅ All rejected with clear error |
| `--help` output | ✅ Clean help text |
| TypeScript compilation (`tsc --noEmit`) | ✅ No errors |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-445bd9bf-3146-4a3b-bc4f-5c5711871965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-445bd9bf-3146-4a3b-bc4f-5c5711871965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

