### PR TITLE
fix: default Docker image to stdio transport (closes #33, #35)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,5 @@ COPY --from=builder /app/dist ./dist
 # Ensure executable permissions
 RUN chmod +x dist/index.cjs
 
-# Set HTTP transport mode by default
-ENV TRANSPORT=http
-
 EXPOSE 8080
 ENTRYPOINT ["node", "dist/index.cjs"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -26,3 +26,10 @@ startCommand:
 build:
   dockerfile: "Dockerfile"
   dockerBuildPath: "."
+
+# Set transport mode for the Smithery.ai environment.
+# The Dockerfile no longer hardcodes TRANSPORT=http so that the image
+# defaults to stdio for Docker MCP Gateway / Gemini CLI consumers.
+# Smithery deploys still need HTTP, declared here at the platform layer.
+env:
+  TRANSPORT: "http"


### PR DESCRIPTION
## Problem

`Dockerfile:28` hardcodes `ENV TRANSPORT=http`, forcing every container to start an HTTP server on port 8080. This breaks:

- **Docker MCP Gateway** (#35) — spawns containers over stdio, never sends HTTP, times out.
- **Gemini CLI** via Docker MCP catalog (#33) — same root cause.

## Fix

Remove the line. `index.ts:40` already defaults to stdio when `TRANSPORT` is unset:

```typescript
const TRANSPORT_TYPE = (process.env.TRANSPORT || 'stdio') as 'stdio' | 'http'
```

```diff
 RUN chmod +x dist/index.cjs

-# Set HTTP transport mode by default
-ENV TRANSPORT=http
-
 EXPOSE 8080
 ENTRYPOINT ["node", "dist/index.cjs"]
```

HTTP mode still available via `-e TRANSPORT=http`.

## Validation

```
$ env -u TRANSPORT REF_API_KEY=test node dist/index.cjs
Ref MCP Server running on stdio

$ TRANSPORT=http PORT=8081 REF_API_KEY=test node dist/index.cjs
Ref MCP Server running on HTTP at http://localhost:8081/mcp
```

`npm run check` passes.

## Smithery

`smithery.yaml` declares `startCommand.type: http`. Smithery's own [`migrate_stdio_to_http` cookbook](https://github.com/smithery-ai/smithery-cookbook/tree/main/servers/python/migrate_stdio_to_http) ships a Dockerfile that does **not** set `TRANSPORT` and still deploys successfully — so Smithery injects it (or routes HTTP) at the platform level, and the Dockerfile ENV is redundant for that path.

Happy to do a Smithery test deploy of this branch before merging if you'd prefer empirical confirmation over the cookbook precedent.

## Backwards compatibility

- `docker run -e TRANSPORT=http -p 8080:8080 …` unchanged.
- Smithery deployment unchanged (platform sets the env).
- New default unblocks stdio clients (Docker MCP Gateway, Gemini CLI, Cursor stdio).

Closes #33
Closes #35
