### PR TITLE
fix: use trailing slash on multi-source COPY destinations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:lts-alpine AS builder
 WORKDIR /app
 
 # Install dependencies and build
-COPY package.json package-lock.json tsconfig.json .
+COPY package.json package-lock.json tsconfig.json ./
 RUN npm ci --ignore-scripts
 COPY index.ts .
 RUN npm run build
@@ -15,7 +15,7 @@ FROM node:lts-alpine
 WORKDIR /app
 
 # Copy runtime dependencies
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm ci --production --ignore-scripts
 
 # Copy built files


### PR DESCRIPTION
`docker build` fails on current Docker (BuildKit, default since Docker 23) because two `COPY` lines use `.` as the destination with multiple sources:

```
Step 3/14 : COPY package.json package-lock.json tsconfig.json .
When using COPY with more than one source file, the destination must
be a directory and end with a /
```

The [Dockerfile reference](https://docs.docker.com/reference/dockerfile/#copy) requires a trailing `/` for multi-source copies. Changing `.` → `./` on the two affected lines fixes the build.

```diff
-COPY package.json package-lock.json tsconfig.json .
+COPY package.json package-lock.json tsconfig.json ./

-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
```

Single-source `COPY` lines are untouched.

Verified locally on Docker 28.5.1 — build completes and `docker run -e REF_API_KEY=test ...` starts as expected. Independent of #47 (different lines); built both layered together too with no conflict.