### PR TITLE
Add the `ref` CLI: reviews --watch, guidance, login (Local Agents v1)

### DIFF
--- a/cli/config.ts
+++ b/cli/config.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Local config + credential resolution for the `ref` CLI.
+ *
+ * The CLI is a thin HTTP client to the Ref plan server. All it needs locally is
+ * (1) an API key and (2) the plan-server base URL. Both are resolved with env
+ * taking precedence over the on-disk `~/.ref/config.json` written by the
+ * installer / `ref login`, so containers and CI can override without a file.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+/** Shape of `~/.ref/config.json` (shared with the install script). */
+export interface RefConfig {
+  apiKey?: string
+  /** Plan-server base URL (e.g. https://api.plan.ref.tools). */
+  apiBaseUrl?: string
+  /** Legacy alias for apiBaseUrl, honored on read. */
+  baseUrl?: string
+  /** Plan web app origin (e.g. https://plan.ref.tools). */
+  appUrl?: string
+  /** Main Ref app origin (e.g. https://ref.tools), home of the keys page. */
+  refAppUrl?: string
+}
+
+const DEFAULT_PLAN_BASE_URL = 'https://api.plan.ref.tools'
+const DEFAULT_APP_URL = 'https://plan.ref.tools'
+const DEFAULT_REF_APP_URL = 'https://ref.tools'
+
+export function getConfigDir(): string {
+  return join(homedir(), '.ref')
+}
+
+export function getConfigPath(): string {
+  return join(getConfigDir(), 'config.json')
+}
+
+export function getGuidanceCachePath(): string {
+  return join(getConfigDir(), 'guidance-cache.json')
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '')
+}
+
+/** Read `~/.ref/config.json`, returning an empty object if missing/unparseable. */
+export function readConfig(): RefConfig {
+  const path = getConfigPath()
+  if (!existsSync(path)) return {}
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as RefConfig
+  } catch {
+    return {}
+  }
+}
+
+/** Merge updates into `~/.ref/config.json`, creating it `0600` if needed. */
+export function writeConfig(updates: Partial<RefConfig>): void {
+  const dir = getConfigDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+  const merged = { ...readConfig(), ...updates }
+  const path = getConfigPath()
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 })
+}
+
+/**
+ * Resolve the API key. Env wins so CI / containers / a remote agent machine can
+ * override a key written by `ref login` on a different host.
+ */
+export function resolveApiKey(config: RefConfig = readConfig()): string | undefined {
+  return process.env.REF_API_KEY || process.env.REF_ALPHA || config.apiKey || undefined
+}
+
+/**
+ * Resolve the plan-server base URL (where review-status + guidance live). This
+ * is distinct from the doc-search API (`REF_URL` / api.ref.tools).
+ */
+export function resolvePlanBaseUrl(config: RefConfig = readConfig()): string {
+  const fromEnv = process.env.REF_PLAN_URL || process.env.REF_API_BASE_URL
+  const resolved = fromEnv || config.apiBaseUrl || config.baseUrl || DEFAULT_PLAN_BASE_URL
+  return trimTrailingSlash(resolved)
+}
+
+/** Resolve the plan web app origin (used for plan links). */
+export function resolveAppUrl(config: RefConfig = readConfig()): string {
+  return trimTrailingSlash(process.env.REF_APP_PLAN_URL || config.appUrl || DEFAULT_APP_URL)
+}
+
+/** Resolve the main Ref app origin (home of the API-key page for `ref login`). */
+export function resolveRefAppUrl(config: RefConfig = readConfig()): string {
+  return trimTrailingSlash(process.env.REF_APP_URL || config.refAppUrl || DEFAULT_REF_APP_URL)
+}
+
+export { dirname, join }

--- a/cli/dispatch.ts
+++ b/cli/dispatch.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Subcommand dispatch for the `ref` CLI.
+ *
+ * The package grew from "an MCP server" into "the `ref` CLI": a bare invocation
+ * (how MCP clients launch it) still boots the stdio server, while explicit
+ * subcommands — `reviews`, `guidance`, `login` — drive the local-agent loop.
+ * Keep this surface deliberately small: it's a thin agent-invoked footprint,
+ * not a CLI product.
+ */
+
+import pkg from '../package.json'
+import { runGuidance } from './guidance.js'
+import { runLogin } from './login.js'
+import { runReviews } from './reviews.js'
+
+const CLI_COMMANDS = new Set(['reviews', 'guidance', 'login', 'help', '--help', '-h', '--version'])
+
+/**
+ * True when argv[2] is a CLI subcommand. A bare invocation or `mcp` is NOT a CLI
+ * command — those fall through to the MCP server for backward compatibility.
+ */
+export function isCliCommand(command: string | undefined): boolean {
+  return command != null && CLI_COMMANDS.has(command)
+}
+
+const HELP = `ref ${pkg.version} — Ref CLI
+
+Usage: ref <command> [options]
+
+Commands:
+  mcp                       Run the Ref documentation-search MCP server (default)
+  reviews <planId> --watch  Block until a plan's review settles, then print the verdict
+  guidance                  Print the server-authored planning guidance (cached, fail-safe)
+  login                     Sign in and store your API key in ~/.ref/config.json
+  help                      Show this help
+
+Run with no command to start the MCP server (how MCP clients launch it).
+`
+
+export async function runCliCommand(command: string | undefined, rest: string[]): Promise<number> {
+  switch (command) {
+    case 'reviews':
+      return runReviews(rest)
+    case 'guidance':
+      return runGuidance(rest)
+    case 'login':
+      return runLogin(rest)
+    case '--version':
+      process.stdout.write(`${pkg.version}\n`)
+      return 0
+    case 'help':
+    case '--help':
+    case '-h':
+      process.stdout.write(HELP)
+      return 0
+    default:
+      process.stderr.write(`Unknown command: ${command}\n\n${HELP}`)
+      return 1
+  }
+}

--- a/cli/guidance.ts
+++ b/cli/guidance.ts
@@ -74,7 +74,11 @@ function writeCache(cache: GuidanceCache): void {
 
 function cacheAgeMs(cache: GuidanceCache): number {
   const fetched = Date.parse(cache.fetchedAt)
-  return Number.isFinite(fetched) ? Date.now() - fetched : Number.POSITIVE_INFINITY
+  if (!Number.isFinite(fetched)) return Number.POSITIVE_INFINITY
+  const age = Date.now() - fetched
+  // A negative age means a backward clock (or bad timestamp); treat it as stale
+  // so it can't pin the cache as permanently-fresh and suppress refetch.
+  return age < 0 ? Number.POSITIVE_INFINITY : age
 }
 
 function emit(

--- a/cli/guidance.ts
+++ b/cli/guidance.ts
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview `ref guidance` — pull the server-authored planning guidance.
+ *
+ * The load-bearing requirement here is fail-safe: this runs on a hot path with
+ * an unbounded public install base, so it must NEVER hang or hard-fail. It
+ * bounds the fetch with a short timeout, degrades to the last cache, then to a
+ * baseline line, and always exits 0. A fresh cache (< TTL) is served without
+ * any network call, so steady-state adds zero latency.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync } from 'node:fs'
+import { AuthError, fetchGuidance } from './planClient.js'
+import {
+  getConfigDir,
+  getGuidanceCachePath,
+  readConfig,
+  resolveApiKey,
+  resolvePlanBaseUrl,
+} from './config.js'
+
+/** Serve a fresh cache without a network call; refetch past this age. */
+const CACHE_TTL_MS = 60 * 60 * 1000 // ~1h: edits propagate within an hour
+const FETCH_TIMEOUT_MS = 5_000
+
+/**
+ * The never-worse-than-baseline fallback when there is no cache and the fetch
+ * fails. Intentionally featherweight — it must never read as a hard gate.
+ */
+const BASELINE_GUIDANCE =
+  'Use your judgment. For a substantial or multi-step change, consider drafting a Ref plan ' +
+  'and requesting a review before implementing.'
+
+interface GuidanceCache {
+  version: string
+  enabled: boolean
+  guidance: string
+  fetchedAt: string
+}
+
+interface GuidanceArgs {
+  json: boolean
+  refresh: boolean
+}
+
+function parseArgs(argv: string[]): GuidanceArgs {
+  const args: GuidanceArgs = { json: false, refresh: false }
+  for (const arg of argv) {
+    if (arg === '--json') args.json = true
+    else if (arg === '--refresh' || arg === '--no-cache') args.refresh = true
+  }
+  return args
+}
+
+function readCache(): GuidanceCache | undefined {
+  const path = getGuidanceCachePath()
+  if (!existsSync(path)) return undefined
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as GuidanceCache
+  } catch {
+    return undefined
+  }
+}
+
+function writeCache(cache: GuidanceCache): void {
+  const dir = getConfigDir()
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
+  try {
+    writeFileSync(getGuidanceCachePath(), `${JSON.stringify(cache, null, 2)}\n`, { mode: 0o600 })
+  } catch {
+    // A read-only home shouldn't break the loop — degrade silently.
+  }
+}
+
+function cacheAgeMs(cache: GuidanceCache): number {
+  const fetched = Date.parse(cache.fetchedAt)
+  return Number.isFinite(fetched) ? Date.now() - fetched : Number.POSITIVE_INFINITY
+}
+
+function emit(
+  args: GuidanceArgs,
+  payload: { version: string; enabled: boolean; guidance: string },
+  source: 'cache' | 'network' | 'baseline',
+): number {
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ ...payload, source })}\n`)
+  } else if (payload.guidance) {
+    process.stdout.write(`${payload.guidance}\n`)
+  }
+  // Always succeed: the loop must never break because guidance was unavailable.
+  return 0
+}
+
+export async function runGuidance(argv: string[]): Promise<number> {
+  const args = parseArgs(argv)
+  const config = readConfig()
+  const apiKey = resolveApiKey(config)
+  const baseUrl = resolvePlanBaseUrl(config)
+
+  const cache = readCache()
+
+  // Fresh cache: serve without touching the network.
+  if (!args.refresh && cache && cacheAgeMs(cache) < CACHE_TTL_MS) {
+    return emit(args, cache, 'cache')
+  }
+
+  // No key: can't fetch. Degrade to cache, else baseline.
+  if (!apiKey) {
+    if (cache) return emit(args, cache, 'cache')
+    return emit(
+      args,
+      { version: 'baseline', enabled: false, guidance: BASELINE_GUIDANCE },
+      'baseline',
+    )
+  }
+
+  try {
+    const payload = await fetchGuidance(baseUrl, apiKey, FETCH_TIMEOUT_MS)
+    const fresh: GuidanceCache = {
+      version: payload.version,
+      enabled: payload.enabled,
+      guidance: payload.guidance,
+      fetchedAt: new Date().toISOString(),
+    }
+    writeCache(fresh)
+    return emit(args, fresh, 'network')
+  } catch (error) {
+    // AuthError, timeout, non-200, network — all fail safe. Never throw.
+    if (cache) return emit(args, cache, 'cache')
+    const stale = error instanceof AuthError ? 'auth' : 'unreachable'
+    return emit(
+      args,
+      { version: `baseline-${stale}`, enabled: false, guidance: BASELINE_GUIDANCE },
+      'baseline',
+    )
+  }
+}

--- a/cli/login.ts
+++ b/cli/login.ts
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview `ref login` — browser-delegated, guided API-key paste.
+ *
+ * The terminal never creates accounts: it opens the browser (whose existing
+ * signup transparently handles first-timers) and receives a credential back via
+ * a guided paste. The key is validated against the plan server, then written to
+ * `~/.ref/config.json` (0600). Env `REF_API_KEY` still wins at read time, so a
+ * key written here is a convenience, not a lock-in.
+ *
+ * Standalone + resumable: a dropped signup is never a dead end — just re-run.
+ */
+
+import { spawn } from 'node:child_process'
+import { createInterface } from 'node:readline/promises'
+import { AuthError, fetchWhoami } from './planClient.js'
+import {
+  readConfig,
+  resolveAppUrl,
+  resolvePlanBaseUrl,
+  resolveRefAppUrl,
+  writeConfig,
+} from './config.js'
+
+interface LoginArgs {
+  key?: string
+  noBrowser: boolean
+}
+
+function parseArgs(argv: string[]): LoginArgs {
+  const args: LoginArgs = { noBrowser: false }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--key') args.key = argv[++i]
+    else if (arg === '--no-browser') args.noBrowser = true
+  }
+  return args
+}
+
+/** Best-effort: open a URL in the default browser; never fail the flow on it. */
+function openBrowser(url: string): void {
+  const platform = process.platform
+  const command = platform === 'darwin' ? 'open' : platform === 'win32' ? 'cmd' : 'xdg-open'
+  const args = platform === 'win32' ? ['/c', 'start', '', url] : [url]
+  try {
+    const child = spawn(command, args, { stdio: 'ignore', detached: true })
+    child.on('error', () => {})
+    child.unref()
+  } catch {
+    // Headless / no browser — the printed URL is the fallback.
+  }
+}
+
+export async function runLogin(argv: string[]): Promise<number> {
+  const args = parseArgs(argv)
+  const config = readConfig()
+  const baseUrl = resolvePlanBaseUrl(config)
+  const refAppUrl = resolveRefAppUrl(config)
+  const appUrl = resolveAppUrl(config)
+  const keysUrl = `${refAppUrl}/keys?source=cli`
+
+  let apiKey = args.key
+
+  if (!apiKey) {
+    process.stderr.write('\nRef sign-in\n===========\n\n')
+    process.stderr.write(`Opening ${keysUrl} in your browser.\n`)
+    process.stderr.write('Sign in (or sign up), create an API key, and copy it.\n\n')
+    if (!args.noBrowser) openBrowser(keysUrl)
+
+    const rl = createInterface({ input: process.stdin, output: process.stderr })
+    try {
+      apiKey = (await rl.question('Paste your Ref API key: ')).trim()
+    } finally {
+      rl.close()
+    }
+  }
+
+  if (!apiKey) {
+    process.stderr.write('No API key provided. Run `ref login` again when ready.\n')
+    return 1
+  }
+
+  // Validate before persisting so we never write a dead key.
+  process.stderr.write('\nValidating…\n')
+  try {
+    const whoami = await fetchWhoami(baseUrl, apiKey)
+    writeConfig({
+      apiKey,
+      apiBaseUrl: baseUrl,
+      appUrl,
+      refAppUrl,
+    })
+    process.stderr.write(`\n✓ Signed in as ${whoami.email || whoami.uid}\n`)
+    process.stderr.write(`  Config written to ~/.ref/config.json\n`)
+    return 0
+  } catch (error) {
+    if (error instanceof AuthError) {
+      process.stderr.write(
+        '\n✗ That key was rejected. Double-check it and run `ref login` again.\n',
+      )
+      return 1
+    }
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`\n✗ Could not reach Ref to validate the key: ${message}\n`)
+    return 1
+  }
+}

--- a/cli/planClient.ts
+++ b/cli/planClient.ts
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview Thin HTTP client to the Ref plan server for the `ref` CLI.
+ *
+ * Deliberately dumb: it forwards the API key and returns parsed JSON. All
+ * tunable behavior (the guidance text, the review verdict semantics) lives
+ * server-side so an installed CLI rarely needs to change.
+ */
+
+import axios, { type AxiosError } from 'axios'
+
+/** Subset of the plan-server review-status response the watch needs. */
+export interface ReviewStatusResponse {
+  planId: string
+  status: string | null
+  settled: boolean
+  pending: boolean
+  reviewRequestCount: number
+  latestReview: {
+    status: string
+    reviewerEmail: string
+    overallComment?: string
+    commentCount: number
+    submittedAt: string
+  } | null
+  planTitle?: string
+  timedOut: boolean
+}
+
+export interface GuidanceResponse {
+  enabled: boolean
+  version: string
+  /** The pulled guidance text, or empty when guidance is killed/disabled. */
+  guidance: string
+}
+
+export interface WhoamiResponse {
+  ok: boolean
+  uid: string
+  email: string
+  teamId: string | null
+  authType: string
+}
+
+/** Raised for an authenticated request that the server rejected with 401/403. */
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AuthError'
+  }
+}
+
+function authHeaders(apiKey: string): Record<string, string> {
+  return { 'x-ref-api-key': apiKey, 'X-Ref-Api-Key': apiKey }
+}
+
+function isAuthStatus(error: AxiosError): boolean {
+  return error.response?.status === 401 || error.response?.status === 403
+}
+
+/**
+ * GET /api/plans/:planId/review-status. When `waitMs > 0`, requests the
+ * server-side long-poll (`?wait=1`) and gives the socket headroom past the
+ * server window so the wait resolves server-side, not by a client timeout.
+ */
+export async function fetchReviewStatus(
+  baseUrl: string,
+  apiKey: string,
+  planId: string,
+  waitMs: number,
+): Promise<ReviewStatusResponse> {
+  const wait = waitMs > 0
+  const url = `${baseUrl}/api/plans/${encodeURIComponent(planId)}/review-status`
+  try {
+    const response = await axios.get<ReviewStatusResponse>(url, {
+      headers: authHeaders(apiKey),
+      params: wait ? { wait: 1 } : {},
+      // Let the held long-poll resolve server-side; only bail well past it.
+      timeout: wait ? waitMs + 15_000 : 15_000,
+    })
+    return response.data
+  } catch (error) {
+    if (axios.isAxiosError(error) && isAuthStatus(error)) {
+      throw new AuthError('Authentication failed')
+    }
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      throw new Error(`Plan not found: ${planId}`)
+    }
+    throw error
+  }
+}
+
+/** GET /api/guidance — short timeout; auth failures surface as AuthError. */
+export async function fetchGuidance(
+  baseUrl: string,
+  apiKey: string,
+  timeoutMs: number,
+): Promise<GuidanceResponse> {
+  const url = `${baseUrl}/api/guidance`
+  try {
+    const response = await axios.get<GuidanceResponse>(url, {
+      headers: authHeaders(apiKey),
+      timeout: timeoutMs,
+    })
+    return response.data
+  } catch (error) {
+    if (axios.isAxiosError(error) && isAuthStatus(error)) {
+      throw new AuthError('Authentication failed')
+    }
+    throw error
+  }
+}
+
+/** GET /plugins/whoami — validates a key and returns the resolved identity. */
+export async function fetchWhoami(baseUrl: string, apiKey: string): Promise<WhoamiResponse> {
+  const url = `${baseUrl}/plugins/whoami`
+  try {
+    const response = await axios.get<WhoamiResponse>(url, {
+      headers: authHeaders(apiKey),
+      timeout: 15_000,
+    })
+    return response.data
+  } catch (error) {
+    if (axios.isAxiosError(error) && isAuthStatus(error)) {
+      throw new AuthError('Authentication failed')
+    }
+    throw error
+  }
+}

--- a/cli/planClient.ts
+++ b/cli/planClient.ts
@@ -49,6 +49,14 @@ export class AuthError extends Error {
   }
 }
 
+/** Raised for a 404 — a permanent condition the watch should not retry. */
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
 function authHeaders(apiKey: string): Record<string, string> {
   return { 'x-ref-api-key': apiKey, 'X-Ref-Api-Key': apiKey }
 }
@@ -83,7 +91,7 @@ export async function fetchReviewStatus(
       throw new AuthError('Authentication failed')
     }
     if (axios.isAxiosError(error) && error.response?.status === 404) {
-      throw new Error(`Plan not found: ${planId}`)
+      throw new NotFoundError(`Plan not found: ${planId}`)
     }
     throw error
   }

--- a/cli/reviews.ts
+++ b/cli/reviews.ts
@@ -1,0 +1,172 @@
+/**
+ * @fileoverview `ref reviews <planId> --watch` — block on a plan's review verdict.
+ *
+ * Mirrors the `gh pr checks --watch` mental model the model already knows: it
+ * re-issues the server long-poll until the review settles, then prints the
+ * verdict. The verdict goes to stdout (pipeable); human status + comments go to
+ * stderr. Crucially it survives a harness shell/tool timeout — each server poll
+ * returns within a bounded window, so a killed `--watch` just needs re-running,
+ * and the agent is told exactly that.
+ */
+
+import { AuthError, fetchReviewStatus, type ReviewStatusResponse } from './planClient.js'
+import { readConfig, resolveApiKey, resolvePlanBaseUrl } from './config.js'
+
+/** Server holds its long-poll for ~25s; give the socket headroom past that. */
+const SERVER_WAIT_WINDOW_MS = 25_000
+const DEFAULT_INTERVAL_MS = 2_000
+const MAX_CONSECUTIVE_ERRORS = 5
+
+interface ReviewsArgs {
+  planId?: string
+  watch: boolean
+  intervalMs: number
+  json: boolean
+}
+
+function parseArgs(argv: string[]): ReviewsArgs {
+  const args: ReviewsArgs = { watch: false, intervalMs: DEFAULT_INTERVAL_MS, json: false }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--watch' || arg === '-w') {
+      args.watch = true
+    } else if (arg === '--json') {
+      args.json = true
+    } else if (arg === '--interval') {
+      const next = argv[++i]
+      const seconds = Number(next)
+      if (Number.isFinite(seconds) && seconds >= 0) args.intervalMs = seconds * 1000
+    } else if (arg && !arg.startsWith('-') && !args.planId) {
+      args.planId = arg
+    }
+  }
+  return args
+}
+
+function verdictLabel(status: string | null): string {
+  switch (status) {
+    case 'plan_approved':
+      return '✓ Approved'
+    case 'changes_requested':
+      return '✗ Changes requested'
+    case 'commented':
+      return '✱ Commented'
+    case 'declined':
+      return '⊘ Review declined'
+    default:
+      return status ?? 'unknown'
+  }
+}
+
+function printSettled(snapshot: ReviewStatusResponse, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(snapshot)}\n`)
+  } else {
+    // stdout: the raw verdict, for piping / programmatic reads.
+    process.stdout.write(`${snapshot.status}\n`)
+  }
+
+  // stderr: human-facing status + the denormalized overall comment.
+  process.stderr.write(`\n${verdictLabel(snapshot.status)}\n`)
+  const review = snapshot.latestReview
+  if (review) {
+    if (review.overallComment) {
+      process.stderr.write(`\n${review.reviewerEmail} wrote:\n${review.overallComment}\n`)
+    }
+    if (review.commentCount > 0) {
+      process.stderr.write(
+        `\n${review.commentCount} inline comment${review.commentCount === 1 ? '' : 's'} — ` +
+          `read them with the Plan MCP Comments tool (action: "list").\n`,
+      )
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function runReviews(argv: string[]): Promise<number> {
+  const args = parseArgs(argv)
+  const config = readConfig()
+  const apiKey = resolveApiKey(config)
+  const baseUrl = resolvePlanBaseUrl(config)
+
+  if (!args.planId) {
+    process.stderr.write('Usage: ref reviews <planId> [--watch] [--interval <seconds>] [--json]\n')
+    return 1
+  }
+  if (!apiKey) {
+    process.stderr.write('Not authenticated. Run `ref login` to sign in.\n')
+    return 1
+  }
+
+  // Single read: report current status and exit.
+  if (!args.watch) {
+    try {
+      const snapshot = await fetchReviewStatus(baseUrl, apiKey, args.planId, 0)
+      if (args.json) {
+        process.stdout.write(`${JSON.stringify(snapshot)}\n`)
+      } else {
+        process.stdout.write(`${snapshot.status ?? 'none'}\n`)
+        process.stderr.write(
+          `${snapshot.settled ? verdictLabel(snapshot.status) : 'Not settled'}\n`,
+        )
+      }
+      return 0
+    } catch (error) {
+      return reportError(error)
+    }
+  }
+
+  process.stderr.write(`Waiting for a review verdict on ${args.planId}…\n`)
+  let consecutiveErrors = 0
+
+  for (;;) {
+    let snapshot: ReviewStatusResponse
+    try {
+      snapshot = await fetchReviewStatus(baseUrl, apiKey, args.planId, SERVER_WAIT_WINDOW_MS)
+      consecutiveErrors = 0
+    } catch (error) {
+      if (error instanceof AuthError) {
+        process.stderr.write(
+          'Authentication failed — run `ref login` to re-authenticate, then retry.\n',
+        )
+        return 1
+      }
+      consecutiveErrors++
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        return reportError(error)
+      }
+      // Transient network error: back off and keep waiting.
+      process.stderr.write(
+        `Network error reaching Ref (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}), retrying…\n`,
+      )
+      await sleep(Math.min(args.intervalMs * consecutiveErrors, 15_000))
+      continue
+    }
+
+    if (snapshot.settled) {
+      printSettled(snapshot, args.json)
+      return 0
+    }
+
+    // No review was ever requested for this plan — nothing to wait on.
+    if (snapshot.reviewRequestCount === 0 && !snapshot.pending) {
+      process.stderr.write(
+        'No review has been requested for this plan. Request a review first, then watch.\n',
+      )
+      return 0
+    }
+
+    // Window elapsed without settling — re-issue so an arbitrarily long human
+    // review survives even if the harness kills any single `--watch` call.
+    if (args.intervalMs > 0) await sleep(args.intervalMs)
+  }
+}
+
+function reportError(error: unknown): number {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`Error: ${message}\n`)
+  return 1
+}

--- a/cli/reviews.ts
+++ b/cli/reviews.ts
@@ -9,13 +9,20 @@
  * and the agent is told exactly that.
  */
 
-import { AuthError, fetchReviewStatus, type ReviewStatusResponse } from './planClient.js'
+import {
+  AuthError,
+  NotFoundError,
+  fetchReviewStatus,
+  type ReviewStatusResponse,
+} from './planClient.js'
 import { readConfig, resolveApiKey, resolvePlanBaseUrl } from './config.js'
 
 /** Server holds its long-poll for ~25s; give the socket headroom past that. */
 const SERVER_WAIT_WINDOW_MS = 25_000
 const DEFAULT_INTERVAL_MS = 2_000
 const MAX_CONSECUTIVE_ERRORS = 5
+/** Floor for error-path backoff so `--interval 0` can't busy-loop on failures. */
+const ERROR_BACKOFF_BASE_MS = 1_000
 
 interface ReviewsArgs {
   planId?: string
@@ -33,9 +40,14 @@ function parseArgs(argv: string[]): ReviewsArgs {
     } else if (arg === '--json') {
       args.json = true
     } else if (arg === '--interval') {
-      const next = argv[++i]
+      // Only consume the next token as the value if it's a valid number;
+      // otherwise leave it (it may be the planId) and ignore the bad flag.
+      const next = argv[i + 1]
       const seconds = Number(next)
-      if (Number.isFinite(seconds) && seconds >= 0) args.intervalMs = seconds * 1000
+      if (next !== undefined && Number.isFinite(seconds) && seconds >= 0) {
+        args.intervalMs = seconds * 1000
+        i++
+      }
     } else if (arg && !arg.startsWith('-') && !args.planId) {
       args.planId = arg
     }
@@ -134,6 +146,11 @@ export async function runReviews(argv: string[]): Promise<number> {
         )
         return 1
       }
+      // A 404 is permanent (wrong/deleted planId) — fail fast, don't retry.
+      if (error instanceof NotFoundError) {
+        process.stderr.write(`${error.message} — check the plan ID.\n`)
+        return 1
+      }
       consecutiveErrors++
       if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
         return reportError(error)
@@ -142,7 +159,9 @@ export async function runReviews(argv: string[]): Promise<number> {
       process.stderr.write(
         `Network error reaching Ref (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}), retrying…\n`,
       )
-      await sleep(Math.min(args.intervalMs * consecutiveErrors, 15_000))
+      await sleep(
+        Math.min(Math.max(args.intervalMs, ERROR_BACKOFF_BASE_MS) * consecutiveErrors, 15_000),
+      )
       continue
     }
 

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import {
 import axios from 'axios'
 import { createServer } from 'http'
 import { randomUUID } from 'crypto'
+import { isCliCommand, runCliCommand } from './cli/dispatch.js'
 
 // Tool configuration based on client type
 type ToolConfig = {
@@ -578,10 +579,23 @@ process.on('SIGINT', async () => {
   process.exit(0)
 })
 
-main().catch((error) => {
-  console.error('Fatal error running server:', error)
-  process.exit(1)
-})
+// Subcommand dispatch. A bare invocation (how MCP clients launch this via
+// `npx ref-tools-mcp`) and an explicit `ref mcp` both boot the MCP server; the
+// CLI subcommands (`reviews`, `guidance`, `login`) drive the local-agent loop.
+const cliCommand = process.argv[2]
+if (isCliCommand(cliCommand)) {
+  runCliCommand(cliCommand, process.argv.slice(3))
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error))
+      process.exit(1)
+    })
+} else {
+  main().catch((error) => {
+    console.error('Fatal error running server:', error)
+    process.exit(1)
+  })
+}
 
 // Export the server for smithery
 export default function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "ref-tools-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ref-tools-mcp",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@modelcontextprotocol/inspector": "^0.16.1",
         "@modelcontextprotocol/sdk": "^1.0.3",
         "axios": "^1.8.4"
       },
       "bin": {
+        "ref": "dist/index.cjs",
         "ref-tools-mcp": "dist/index.cjs"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ref-tools-mcp",
-  "version": "3.0.3",
-  "description": "ModelContextProtocol server for Ref",
+  "version": "3.1.0",
+  "description": "ModelContextProtocol server for Ref, plus the ref CLI (reviews, guidance, login)",
   "mcpName": "io.github.ref-tools/ref-tools-mcp",
   "type": "module",
   "module": "index.ts",
@@ -17,6 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "bin": {
+    "ref": "./dist/index.cjs",
     "ref-tools-mcp": "./dist/index.cjs"
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "composite": true
   },
   "include": [
-    "**/*.ts"
+    "**/*.ts",
+    "package.json"
   ],
 }


### PR DESCRIPTION
## The `ref` CLI — client half of Local Agents + Ref

Implements the CLI half of the [Local Agents + Ref plan](https://plan.staging-ref.tools/kmrzdDZBwgSDT6NR). The server half (endpoints) is in [`ref-tools/ref#1475`](https://github.com/ref-tools/ref/pull/1475).

Grows this public, branded package from "an MCP server" into "the `ref` CLI," with the doc-search server demoted to the default / `ref mcp` subcommand. The CLI is the **thin, agent-invoked** client of the plan → review → resume loop — a dumb HTTP pipe; all tunable behavior stays server-side.

### Commands
- **`ref reviews <planId> --watch`** — re-issues the server long-poll until the review settles, then prints the verdict to **stdout** (pipeable) and human status + the reviewer's comment to **stderr**. Survives a harness command timeout by re-issuing (each server window is bounded); on a bad key it reports an auth error and exits non-zero instead of hanging. Mirrors the `gh pr checks --watch` mental model the model already knows.
- **`ref guidance`** — pulls server-authored planning guidance, writes it to `~/.ref/guidance-cache.json`, and prints it. **Fail-safe is the load-bearing requirement:** a fresh cache (< ~1h TTL) is served with no network call; on auth/network/non-200/timeout it degrades to the last cache, then to a baseline line, and **always exits 0** — the loop never breaks because a fetch failed.
- **`ref login`** — browser-delegated, guided API-key paste. Opens the keys page, takes the pasted key, validates it against the plan server, and writes `~/.ref/config.json` (`0600`). Standalone + resumable.

### Backward compatibility
- A **bare invocation** (`npx ref-tools-mcp`, how MCP clients launch it) and `ref mcp` both still boot the stdio MCP doc-search server unchanged — existing client configs keep working.
- Adds a `ref` bin alongside `ref-tools-mcp`; bumps to `3.1.0`.

### Layout
`cli/` — `config.ts` (key + plan-base-url resolution; env wins over `~/.ref/config.json`), `planClient.ts` (HTTP to the plan server), `reviews.ts` / `guidance.ts` / `login.ts`, and `dispatch.ts` (subcommand routing + help). The MCP server in `index.ts` is untouched except the dispatch shim at the bottom.

### Testing
- `npm run check` (tsc) + `npm run build` (esbuild bundle) green.
- Verified end-to-end against a faithful server contract using the **real built CLI**: the full `watch → verdict → resume` loop (incl. re-issue across short server windows), `ref guidance` network→cache→cache-hit and dead-server fail-safe, `ref login` validate+persist, and bad-key → auth-error-exit-1 (no hang).

### Cross-repo contract
The endpoints live in `ref-tools/ref`; this CLI is a thin HTTP client to them. The contract is held backward-compatible so an installed CLI can lag deployed endpoints.

---
_Generated by [Claude Code](https://claude.ai/code/session_018gmZrNy3EFvfrNjPWovDZB)_